### PR TITLE
Add mouse support

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ If `deltCrossAxis * ignoreCrossMove > deltMainAxis`, carousel would ignore the d
 
 `true` as `1` and `false` as `0`. Default `true`.
 
+### props.mouseSupport {Boolean}
+
+If this is set to `true`, desktop users can drag the carousel using the mouse.
+
 ## Concepts
 
 ### Cursor

--- a/examples/boring/index.css
+++ b/examples/boring/index.css
@@ -12,14 +12,6 @@ h1 {
   text-align: center;
 }
 
-#mobile-tip {
-  text-align: center;
-}
-
-#mobile-tip:not([hidden]) ~ #react-root {
-  opacity: 0.1;
-}
-
 .carousel-container {
   position: relative;
   height: 300px;

--- a/examples/boring/index.html
+++ b/examples/boring/index.html
@@ -12,7 +12,6 @@
   <body>
     <main>
       <h1>react-touch-carousel</h1>
-      <p id="mobile-tip" hidden>Please open this page on a mobile device.</p>
       <div id="react-root" class="container"></div>
       <pre id="option-explain" class="ui-center"></pre>
       <pre class="ui-center"><code id="console" ></code></pre>

--- a/examples/boring/index.js
+++ b/examples/boring/index.js
@@ -85,6 +85,7 @@ class App extends Component {
         loop={enableLoop}
         autoplay={enableAutoplay ? 2e3 : false}
         renderCard={this.renderCard}
+        mouseSupport
         onRest={index => log(`rest at index ${index}`)}
         onDragStart={() => log('dragStart')}
         onDragEnd={() => log('dragEnd')}
@@ -97,9 +98,6 @@ class App extends Component {
 document.addEventListener('DOMContentLoaded', function () {
   const ndRoot = document.getElementById('react-root')
   render(<App />, ndRoot)
-  if (!('ontouchmove' in window)) {
-    document.getElementById('mobile-tip').removeAttribute('hidden')
-  }
 
   let optionExplain = []
   if (enableLoop) {

--- a/examples/cascade/index.css
+++ b/examples/cascade/index.css
@@ -20,14 +20,6 @@ h1 {
   text-align: center;
 }
 
-#mobile-tip {
-  text-align: center;
-}
-
-#mobile-tip:not([hidden]) ~ #react-root {
-  opacity: 0.1;
-}
-
 .carousel-container {
   height: 300px;
   max-width: 960px;

--- a/examples/cascade/index.html
+++ b/examples/cascade/index.html
@@ -12,7 +12,6 @@
   <body>
     <main>
       <h1>react-touch-carousel</h1>
-      <p id="mobile-tip" hidden>Please open this page on a mobile device.</p>
       <div id="react-root" class="container"></div>
       <pre class="ui-center"><code>loop autoplay=3000</code></pre>
     </main>

--- a/examples/cascade/index.js
+++ b/examples/cascade/index.js
@@ -68,7 +68,8 @@ class App extends Component {
         cardPadCount={cardPadCount}
         autoplay={3e3}
         renderCard={this.renderCard}
-      />
+        mouseSupport
+        />
     )
   }
 }
@@ -76,7 +77,4 @@ class App extends Component {
 document.addEventListener('DOMContentLoaded', function () {
   const ndRoot = document.getElementById('react-root')
   render(<App />, ndRoot)
-  if (!('ontouchmove' in window)) {
-    document.getElementById('mobile-tip').removeAttribute('hidden')
-  }
 })

--- a/examples/cd/index.css
+++ b/examples/cd/index.css
@@ -12,14 +12,6 @@ h1 {
   text-align: center;
 }
 
-#mobile-tip {
-  text-align: center;
-}
-
-#mobile-tip:not([hidden]) ~ #react-root {
-  opacity: 0.1;
-}
-
 .carousel-container {
   position: relative;
   height: 300px;

--- a/examples/cd/index.html
+++ b/examples/cd/index.html
@@ -12,7 +12,6 @@
   <body>
     <main>
       <h1>react-touch-carousel</h1>
-      <p id="mobile-tip" hidden>Please open this page on a mobile device.</p>
       <div id="react-root" class="container"></div>
       <pre class="ui-center"><code>loop autoplay=5000</code></pre>
       <pre id="iOS-bug" class="ui-center" hidden>Safari is buggy at animation-play-state</pre>

--- a/examples/cd/index.js
+++ b/examples/cd/index.js
@@ -74,6 +74,7 @@ class App extends Component {
         renderCard={this.renderCard}
         onRest={this.onRest}
         data-playing={this.state.playing}
+        mouseSupport
       />
     )
   }
@@ -82,9 +83,6 @@ class App extends Component {
 document.addEventListener('DOMContentLoaded', function () {
   const ndRoot = document.getElementById('react-root')
   render(<App />, ndRoot)
-  if (!('ontouchmove' in window)) {
-    document.getElementById('mobile-tip').removeAttribute('hidden')
-  }
 
   if (/iPhone|iPad/.test(navigator.userAgent)) {
     document.getElementById('iOS-bug').removeAttribute('hidden')

--- a/examples/fade/index.css
+++ b/examples/fade/index.css
@@ -12,14 +12,6 @@ h1 {
   text-align: center;
 }
 
-#mobile-tip {
-  text-align: center;
-}
-
-#mobile-tip:not([hidden]) ~ #react-root {
-  opacity: 0.1;
-}
-
 .carousel-container {
   position: relative;
   height: 300px;

--- a/examples/fade/index.html
+++ b/examples/fade/index.html
@@ -12,7 +12,6 @@
   <body>
     <main>
       <h1>react-touch-carousel</h1>
-      <p id="mobile-tip" hidden>Please open this page on a mobile device.</p>
       <div id="react-root" class="container"></div>
       <pre class="ui-center">loop autoplay=2000</pre>
       <pre class="ui-center"><code id="console" ></code></pre>

--- a/examples/fade/index.js
+++ b/examples/fade/index.js
@@ -53,7 +53,8 @@ class App extends Component {
         autoplay={2e3}
         renderCard={this.renderCard}
         stiffness={100}
-      />
+        mouseSupport
+        />
     )
   }
 }
@@ -61,7 +62,4 @@ class App extends Component {
 document.addEventListener('DOMContentLoaded', function () {
   const ndRoot = document.getElementById('react-root')
   render(<App />, ndRoot)
-  if (!('ontouchmove' in window)) {
-    document.getElementById('mobile-tip').removeAttribute('hidden')
-  }
 })

--- a/examples/reuse/index.css
+++ b/examples/reuse/index.css
@@ -12,14 +12,6 @@ h1 {
   text-align: center;
 }
 
-#mobile-tip {
-  text-align: center;
-}
-
-#mobile-tip:not([hidden]) ~ #react-root {
-  opacity: 0.1;
-}
-
 .carousel-container {
   position: relative;
   height: 300px;

--- a/examples/reuse/index.html
+++ b/examples/reuse/index.html
@@ -12,7 +12,6 @@
   <body>
     <main>
       <h1>react-touch-carousel</h1>
-      <p id="mobile-tip" hidden>Please open this page on a mobile device.</p>
       <div id="react-root" class="container"></div>
       <pre class="ui-center">3 card nodes rendering 1000 items.<br>URL query like `?20` to set start. </pre>
     </main>

--- a/examples/reuse/index.js
+++ b/examples/reuse/index.js
@@ -99,7 +99,8 @@ class App extends Component {
         loop={false}
         renderCard={this.renderCard}
         defaultCursor={this.defaultCursor}
-      />
+        mouseSupport
+        />
     )
   }
 }
@@ -107,7 +108,4 @@ class App extends Component {
 document.addEventListener('DOMContentLoaded', function () {
   const ndRoot = document.getElementById('react-root')
   render(<App />, ndRoot)
-  if (!('ontouchmove' in window)) {
-    document.getElementById('mobile-tip').removeAttribute('hidden')
-  }
 })

--- a/examples/rolling/index.css
+++ b/examples/rolling/index.css
@@ -12,14 +12,6 @@ h1 {
   text-align: center;
 }
 
-#mobile-tip {
-  text-align: center;
-}
-
-#mobile-tip:not([hidden]) ~ #react-root {
-  opacity: 0.1;
-}
-
 .carousel-container {
   position: relative;
   height: 300px;

--- a/examples/rolling/index.html
+++ b/examples/rolling/index.html
@@ -12,7 +12,6 @@
   <body>
     <main>
       <h1>react-touch-carousel</h1>
-      <p id="mobile-tip" hidden>Please open this page on a mobile device.</p>
       <div id="react-root" class="container"></div>
       <pre class="ui-center">loop autoplay=2000</pre>
       <pre class="ui-center"><code id="console" ></code></pre>

--- a/examples/rolling/index.js
+++ b/examples/rolling/index.js
@@ -54,7 +54,8 @@ class App extends Component {
         cardPadCount={cardPadCount}
         autoplay={2e3}
         renderCard={this.renderCard}
-      />
+        mouseSupport
+        />
     )
   }
 }
@@ -62,7 +63,4 @@ class App extends Component {
 document.addEventListener('DOMContentLoaded', function () {
   const ndRoot = document.getElementById('react-root')
   render(<App />, ndRoot)
-  if (!('ontouchmove' in window)) {
-    document.getElementById('mobile-tip').removeAttribute('hidden')
-  }
 })

--- a/examples/vertical/index.css
+++ b/examples/vertical/index.css
@@ -20,14 +20,6 @@ h1 {
   text-align: center;
 }
 
-#mobile-tip {
-  text-align: center;
-}
-
-#mobile-tip:not([hidden]) ~ #react-root {
-  opacity: 0.1;
-}
-
 .carousel-container {
   height: 300px;
   max-width: 960px;

--- a/examples/vertical/index.html
+++ b/examples/vertical/index.html
@@ -12,7 +12,6 @@
   <body>
     <main>
       <h1>react-touch-carousel</h1>
-      <p id="mobile-tip" hidden>Please open this page on a mobile device.</p>
       <div id="react-root" class="container"></div>
       <pre class="ui-center"><code>vertical loop autoplay=3000</code></pre>
     </main>

--- a/examples/vertical/index.js
+++ b/examples/vertical/index.js
@@ -62,7 +62,4 @@ class App extends Component {
 document.addEventListener('DOMContentLoaded', function () {
   const ndRoot = document.getElementById('react-root')
   render(<App />, ndRoot)
-  if (!('ontouchmove' in window)) {
-    document.getElementById('mobile-tip').removeAttribute('hidden')
-  }
 })


### PR DESCRIPTION
This library offered exactly what I needed, i.e. complete control over the rendering of cards, including the in-between states. I needed mouse support in addition to touch, so I added it in this PR.

Notable things:
- mouse move and up events listeners are added to document, so that user can drag outside the carousel and things work normally
- mouse move and up handlers do nothing, unless we are dragging
- being able to drag outside the carousel exposed a bug where the state was empty until the next start event - fixed by adding `modCursor` on spring rest

Let me know if you need anything to get this merged, we're now building our app on top of my fork, but it would be great to get to get everything upstream.