### PR TITLE
Reset autoplay timer on button press

### DIFF
--- a/examples/boring/index.css
+++ b/examples/boring/index.css
@@ -87,3 +87,8 @@ h1 {
   border-radius: 0;
   background: white;
 }
+
+.button-container {
+  display: flex;
+  justify-content: center;
+}

--- a/examples/boring/index.js
+++ b/examples/boring/index.js
@@ -9,6 +9,7 @@ import './index.css'
 const query = window.location.search.slice(1)
 const enableLoop = /\bloop\b/.test(query)
 const enableAutoplay = /\bautoplay\b/.test(query)
+const enableButtons = /\bbuttons\b/.test(query)
 
 const cardSize = 300
 const cardPadCount = enableLoop ? 3 : 0
@@ -78,8 +79,16 @@ class App extends Component {
     )
   }
 
+  renderButtons () {
+    return <div className='button-container'>
+      <button onClick={() => this.carouselRef && this.carouselRef.prev()}>Prev</button>
+      <button onClick={() => this.carouselRef && this.carouselRef.next()}>Next</button>
+    </div>
+  }
+
   render () {
-    return (
+    return (<div>
+      { enableButtons && this.renderButtons()}
       <TouchCarousel
         component={Container}
         cardSize={cardSize}
@@ -92,8 +101,9 @@ class App extends Component {
         onDragStart={() => log('dragStart')}
         onDragEnd={() => log('dragEnd')}
         onDragCancel={() => log('dragCancel')}
+        ref={r => this.carouselRef = r}
       />
-    )
+    </div>)
   }
 }
 

--- a/examples/boring/index.js
+++ b/examples/boring/index.js
@@ -101,7 +101,7 @@ class App extends Component {
         onDragStart={() => log('dragStart')}
         onDragEnd={() => log('dragEnd')}
         onDragCancel={() => log('dragCancel')}
-        ref={r => this.carouselRef = r}
+        ref={r => { this.carouselRef = r }}
       />
     </div>)
   }

--- a/examples/index.html
+++ b/examples/index.html
@@ -53,6 +53,7 @@
       <ul class="page-list">
         <li><a class="entry-link" href="boring.html">boring</a></li>
         <li><a class="entry-link" href="boring.html?loop&autoplay">loop & autoplay</a></li>
+        <li><a class="entry-link" href="boring.html?loop&autoplay&buttons">loop & autoplay & buttons</a></li>
         <li><a class="entry-link" href="vertical.html">vertical</a></li>
         <li><a class="entry-link" href="cascade.html">cascade</a></li>
         <li><a class="entry-link" href="rolling.html">rolling</a></li>

--- a/src/TouchCarousel.js
+++ b/src/TouchCarousel.js
@@ -213,23 +213,31 @@ class TouchCarousel extends React.PureComponent {
     }
   }
 
+  resetAutoplayTimer = () => {
+    this.stopAutoplay()
+    this.autoplayIfEnabled()
+  }
+
   go = (n) => {
     return this.modCursor().then(() => {
       // n must be in range here.
       // That's why next()/prev() don't use this method.
       this.setCursor(n)
+      this.resetAutoplayTimer()
     })
   }
 
   next = () => {
     return this.modCursor().then(() => {
       this.setCursor(this.state.cursor - 1)
+      this.resetAutoplayTimer()
     })
   }
 
   prev = () => {
     return this.modCursor().then(() => {
       this.setCursor(this.state.cursor + 1)
+      this.resetAutoplayTimer()
     })
   }
 

--- a/src/TouchCarousel.js
+++ b/src/TouchCarousel.js
@@ -202,6 +202,9 @@ class TouchCarousel extends React.PureComponent {
 
   autoplayIfEnabled = () => {
     if (this.props.autoplay) {
+      if (this.autoplayTimer) {
+        clearInterval(this.autoplayTimer)
+      }
       this.autoplayTimer = setInterval(this.next, this.props.autoplay)
     }
   }


### PR DESCRIPTION
Fix next and previous buttons to work sensibly with autoplay: when the user interacts with the carousel, the timer starts from 0. This prevents those weird situations where the user presses next and the autoplay happens immediately after - similar to what already was implemented for user touch.