### PR TITLE
Fix/es2016 includes

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -46,7 +46,7 @@ function getTouchId(e) {
 function omit(obj, keys) {
   var ret = {};
   Object.keys(obj).forEach(function (k) {
-    if (keys.includes(k)) return;
+    if (keys.indexOf(k) !== -1) return;
     ret[k] = obj[k];
   });
   return ret;

--- a/lib/utils.test.js
+++ b/lib/utils.test.js
@@ -8,6 +8,12 @@ var _utils = require('./utils');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+(0, _ava2.default)('omit', function (t) {
+  t.deepEqual((0, _utils.omit)({ a: 'a', b: 'b' }, ['b']), { a: 'a' });
+  t.deepEqual((0, _utils.omit)({ a: 'a', b: 'b' }, ['c']), { a: 'a', b: 'b' });
+  t.deepEqual((0, _utils.omit)({ a: 'a', b: 'b' }, ['a', 'b']), {});
+});
+
 (0, _ava2.default)('modCursor', function (t) {
   t.is((0, _utils.modCursor)(0.9, 7), -6.1);
   t.is((0, _utils.modCursor)(0, 7), 0);

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "build": "for js in src/*.js; do babel $js > \"lib/$(basename $js)\"; done",
     "list-demo": "cd examples; find . -name index.html | xargs -n1 dirname | xargs -n1 basename",
     "docs": "rm -r docs; PAGES=$(npm run -s list-demo) webpack -p",
-    "dev": "PAGES=$(npm run -s list-demo) webpack-dev-server --hot --inline",
-    "prepare": "npm run build"
+    "dev": "PAGES=$(npm run -s list-demo) webpack-dev-server --hot --inline"
   },
   "keywords": [
     "react",

--- a/src/utils.js
+++ b/src/utils.js
@@ -34,7 +34,7 @@ export function getTouchId (e) {
 export function omit (obj, keys) {
   const ret = {}
   Object.keys(obj).forEach(k => {
-    if (keys.includes(k)) return
+    if (keys.indexOf(k) !== -1) return
     ret[k] = obj[k]
   })
   return ret

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,5 +1,11 @@
 import test from 'ava'
-import {modCursor} from './utils'
+import {omit, modCursor} from './utils'
+
+test('omit', t => {
+  t.deepEqual(omit({a: 'a', b: 'b'}, ['b']), {a: 'a'})
+  t.deepEqual(omit({a: 'a', b: 'b'}, ['c']), {a: 'a', b: 'b'})
+  t.deepEqual(omit({a: 'a', b: 'b'}, ['a', 'b']), {})
+})
 
 test('modCursor', t => {
   t.is(modCursor(0.9, 7), -6.1)


### PR DESCRIPTION
## Description

`Array.prototype.includes` is a ES2016 method and is causing some troubles in IE11.

## Solution

### Use `indexOf` instead

THIS PR.

### Or better, use `lodash` + `babel-plugin-lodash` for util functions

`lodash` is widely used in front-end projects and switching to it may save bundle sizes. Combining with `babel-plugin-lodash` can create a minimal build that only includes `lodash` functions used but not the whole `lodash` package.

## References

* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes